### PR TITLE
mrb_ary_len has been removed

### DIFF
--- a/src/editline.c
+++ b/src/editline.c
@@ -236,7 +236,7 @@ mrb_editline_parse(mrb_state *mrb, mrb_value self)
 
   mel = DATA_PTR(self);
   mrb_get_args(mrb, "A", &ary);
-  argc = mrb_ary_len(mrb, ary);
+  argc = RARRAY_LEN(ary);
   if (argc > 16) {
     mrb_raise(mrb, E_ARGUMENT_ERROR, "too many argments (max: 16)");
   }


### PR DESCRIPTION
on https://github.com/mruby/mruby/commit/67e2dddb8
